### PR TITLE
Add Codecov token to workflow for coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
         name: codecov-python-3.13


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration by adding the `CODECOV_TOKEN` secret to the Codecov upload step. This change ensures that coverage reports are properly authenticated and uploaded to Codecov.